### PR TITLE
Make rewire a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "bluebird": "^3.5.0",
     "request": "^2.81.0",
     "@types/bluebird": "*",
-    "@types/request": "*",
-    "rewire": "^3.0.2"
+    "@types/request": "*"
   },
   "devDependencies": {
     "typescript": "^4.3.3",
-    "@types/node": "^15.12.2"
+    "@types/node": "^15.12.2",
+    "rewire": "^3.0.2"
   },
   "bugs": {
     "url": "https://github.com/merge-api/merge-hris-node/issues"


### PR DESCRIPTION
## Description of the change

Changing rewire from a dependency to a dev dependency to prevent unnecessary bloating of package dependencies as it's a unit testing utility library.

Doesn't even seem like it's used, so maybe it can just be removed instead?

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> All PRs at Merge must be backed by an Asana ticket. Create one here, and then replace this line with the link. https://app.asana.com/0/1198991781422585/list
## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.

